### PR TITLE
fix: normalize Graph API errors

### DIFF
--- a/src/api/services/template.service.ts
+++ b/src/api/services/template.service.ts
@@ -3,6 +3,7 @@ import { TemplateDto } from '@api/dto/template.dto';
 import { PrismaRepository } from '@api/repository/repository.service';
 import { ConfigService, WaBusiness } from '@config/env.config';
 import { Logger } from '@config/logger.config';
+import { extractGraphError } from '@utils/extractGraphError';
 import axios from 'axios';
 
 import { WAMonitoringService } from './monitor.service';
@@ -94,8 +95,9 @@ export class TemplateService {
         return result.data;
       }
     } catch (e) {
-      this.logger.error(e.response.data);
-      return e.response.data.error;
+      const { message, status, body } = extractGraphError(e);
+      this.logger.error(`[GraphSendError] status=${status} body=${JSON.stringify(body)?.slice(0, 200)}`);
+      return { message };
     }
   }
 }

--- a/src/utils/__tests__/extractGraphError.test.ts
+++ b/src/utils/__tests__/extractGraphError.test.ts
@@ -1,0 +1,24 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { extractGraphError } from '../extractGraphError';
+
+test('extractGraphError returns message from response.error.message', () => {
+  const err = { response: { status: 400, data: { error: { message: 'Invalid number' } } } };
+  const info = extractGraphError(err);
+  assert.equal(info.message, 'Invalid number');
+  assert.equal(info.status, 400);
+});
+
+test('extractGraphError falls back to stringified body when message missing', () => {
+  const err = { response: { status: 403, data: { status: 403 } } };
+  const info = extractGraphError(err);
+  assert.equal(info.message, JSON.stringify({ status: 403 }));
+  assert.equal(info.status, 403);
+});
+
+test('extractGraphError uses err.message when no response', () => {
+  const err = new Error('Network Error');
+  const info = extractGraphError(err);
+  assert.equal(info.message, 'Network Error');
+  assert.equal(info.status, undefined);
+});

--- a/src/utils/extractGraphError.ts
+++ b/src/utils/extractGraphError.ts
@@ -1,0 +1,12 @@
+export interface GraphErrorInfo {
+  message: string;
+  status?: number;
+  body?: any;
+}
+
+export function extractGraphError(err: any): GraphErrorInfo {
+  const status = err?.response?.status;
+  const body = err?.response?.data;
+  const message = body?.error?.message || err?.message || (body ? JSON.stringify(body) : 'Unknown error');
+  return { message, status, body };
+}


### PR DESCRIPTION
## Summary
- add extractGraphError utility to always return meaningful Graph error messages
- use extractGraphError in WhatsApp Business channel and template service
- add unit tests for error normalization

## Testing
- `npm run lint:check`
- `npx tsx --test src/utils/__tests__/extractGraphError.test.ts`

------