### PR TITLE
Improve Graph API error extraction and logging

### DIFF
--- a/src/api/integrations/channel/meta/whatsapp.business.service.ts
+++ b/src/api/integrations/channel/meta/whatsapp.business.service.ts
@@ -1148,7 +1148,9 @@ export class BusinessStartupService extends ChannelStartupService {
       return messageRaw;
     } catch (error) {
       const { message, status: statusCode, body } = extractGraphError(error);
-      this.logger.error(`[GraphSendError] status=${statusCode} body=${JSON.stringify(body)?.slice(0, 200)}`);
+      this.logger.error(
+        `[GraphSendError] status=${statusCode ?? 'unknown'} body=${JSON.stringify(body ?? null)?.slice(0, 200)}`,
+      );
       throw new BadRequestException(message);
     }
   }
@@ -1215,7 +1217,9 @@ export class BusinessStartupService extends ChannelStartupService {
       return res.data.id;
     } catch (error) {
       const { message, status, body } = extractGraphError(error);
-      this.logger.error(`[GraphSendError] status=${status} body=${JSON.stringify(body)?.slice(0, 200)}`);
+      this.logger.error(
+        `[GraphSendError] status=${status ?? 'unknown'} body=${JSON.stringify(body ?? null)?.slice(0, 200)}`,
+      );
       throw new InternalServerErrorException(message);
     }
   }

--- a/src/api/services/template.service.ts
+++ b/src/api/services/template.service.ts
@@ -96,7 +96,9 @@ export class TemplateService {
       }
     } catch (e) {
       const { message, status, body } = extractGraphError(e);
-      this.logger.error(`[GraphSendError] status=${status} body=${JSON.stringify(body)?.slice(0, 200)}`);
+      this.logger.error(
+        `[GraphSendError] status=${status ?? 'unknown'} body=${JSON.stringify(body ?? null)?.slice(0, 200)}`,
+      );
       return { message };
     }
   }

--- a/src/utils/__tests__/extractGraphError.test.ts
+++ b/src/utils/__tests__/extractGraphError.test.ts
@@ -1,5 +1,6 @@
-import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
 import { extractGraphError } from '../extractGraphError';
 
 test('extractGraphError returns message from response.error.message', () => {
@@ -16,9 +17,18 @@ test('extractGraphError falls back to stringified body when message missing', ()
   assert.equal(info.status, 403);
 });
 
-test('extractGraphError uses err.message when no response', () => {
+test('extractGraphError uses err.status when no response', () => {
+  const err = { status: 504, message: 'Gateway Timeout' };
+  const info = extractGraphError(err);
+  assert.equal(info.message, 'Gateway Timeout');
+  assert.equal(info.status, 504);
+  assert.deepEqual(info.body, { status: 504, message: 'Gateway Timeout' });
+});
+
+test('extractGraphError emits placeholders for pure network errors', () => {
   const err = new Error('Network Error');
   const info = extractGraphError(err);
   assert.equal(info.message, 'Network Error');
-  assert.equal(info.status, undefined);
+  assert.equal(info.status, 'unknown');
+  assert.equal(info.body, null);
 });

--- a/src/utils/extractGraphError.ts
+++ b/src/utils/extractGraphError.ts
@@ -1,12 +1,18 @@
 export interface GraphErrorInfo {
   message: string;
-  status?: number;
-  body?: any;
+  status: number | string;
+  body: any;
 }
 
 export function extractGraphError(err: any): GraphErrorInfo {
-  const status = err?.response?.status;
-  const body = err?.response?.data;
+  const status = err?.response?.status ?? err?.status ?? err?.code ?? 'unknown';
+  let body = err?.response?.data ?? err?.data ?? (err && typeof err === 'object' ? { ...err } : null);
+
+  if (body && typeof body === 'object' && Object.keys(body).length === 0) {
+    body = null;
+  }
+
   const message = body?.error?.message || err?.message || (body ? JSON.stringify(body) : 'Unknown error');
+
   return { message, status, body };
 }


### PR DESCRIPTION
## Summary
- extend `extractGraphError` to derive status and body from multiple sources and normalize missing values
- log normalized status/body in WhatsApp Business and template services
- add unit tests for new error extraction scenarios

## Testing
- `npx tsx --test src/utils/__tests__/extractGraphError.test.ts`
- `npm run lint:check`


------
https://chatgpt.com/codex/tasks/task_e_68c088b5b678832196c1d17fb3a62743